### PR TITLE
Added github url to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Code repository for DA3018 spring 2023
 You will also find example code and stubs for labs 3 through 5.
 
 Make a pull request if you notice errors or see possibilities for improvement!
+
+Online repo available at: https://github.com/arvestad/da3018_vt2023_repo


### PR DESCRIPTION
Nice to have the original github url follow the readme when cloning the repo. Also, tested making a pull request :)